### PR TITLE
passion: Update for new LED capabilities

### DIFF
--- a/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
@@ -23,17 +23,17 @@
     <!-- All the capabilities of the LEDs on this device, stored as a bit field.
          This integer should equal the sum of the corresponding value for each
          of the following capabilities present:
-
          LIGHTS_RGB_NOTIFICATION_LED = 1
          LIGHTS_RGB_BATTERY_LED = 2
-         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4
+         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4 (deprecated)
          LIGHTS_PULSATING_LED = 8
          LIGHTS_SEGMENTED_BATTERY_LED = 16
          LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS = 32
-
-         For example, a device support pulsating, RGB notification and
-         battery LEDs would set this config to 11. -->
-    <integer name="config_deviceLightCapabilities">3</integer>
+         LIGHTS_BATTERY_LED = 64
+         For example, a device with notification and battery lights
+         that support pulsating and RGB control would set this config
+         to 75. -->
+    <integer name="config_deviceLightCapabilities">75</integer>
 
     <!-- Enable the option to check proximity sensor when deciding whether to
          turn the screen on


### PR DESCRIPTION
*) frameworks/base bool config_intrusiveBatteryLed is no longer
   used so it has been removed.

*) Use LIGHTS_BATTERY_LIGHT capability in lineage-sdk instead.

*) Update config_deviceLightCapabilities comments

*) Move bool config_intrusiveNotificationLed out of Lineage-specific
   overlays because it's an AOSP config