### PR TITLE
passion: Remove unused HWC2 HIDLs

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -60,7 +60,6 @@ PRODUCT_PACKAGES += \
     android.hardware.audio.effect@2.0-impl \
     android.hardware.soundtrigger@2.0-impl \
     android.hardware.broadcastradio@1.0-impl \
-    audiod \
     audio.a2dp.default \
     audio.r_submix.default \
     audio.usb.default \
@@ -95,7 +94,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.graphics.allocator@2.0-impl \
     android.hardware.graphics.allocator@2.0-service \
-    android.hardware.graphics.composer@2.1-impl \
     android.hardware.graphics.mapper@2.0-impl \
     android.hardware.memtrack@1.0-impl \
     copybit.msm8916 \


### PR DESCRIPTION
* Causes lags when display transformations are used