### PR TITLE
passion: Fix HWC1 support with surfaceflinger

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,7 +1,7 @@
 <manifest version="1.0" type="device">
     <hal format="hidl">
         <name>android.hardware.graphics.allocator</name>
-        <transport arch="32">passthrough</transport>
+        <transport>hwbinder</transport>
         <version>2.0</version>
         <interface>
             <name>IAllocator</name>
@@ -59,6 +59,15 @@
         <version>2.0</version>
         <interface>
             <name>ILight</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.composer</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IComposer</name>
             <instance>default</instance>
         </interface>
     </hal>


### PR DESCRIPTION
TARGET_USES_HWC2 is now assumed to be always true.
https://android.googlesource.com/platform/frameworks/native/+/d265c4238699ea899cc3b01cc90b643d9692db2a
Add android.hardware.graphics.composer@2.1-impl and
the respective manifest.xml change to use the HWC2on1
adapter.